### PR TITLE
Fix wrong channelId for WBT_CONTEXT

### DIFF
--- a/src/rfxcompose.c
+++ b/src/rfxcompose.c
@@ -65,7 +65,7 @@ rfx_compose_message_context(struct rfxencode* enc, STREAM* s)
     stream_write_uint16(s, WBT_CONTEXT); /* CodecChannelT.blockType */
     stream_write_uint32(s, 13); /* CodecChannelT.blockLen */
     stream_write_uint8(s, 1); /* CodecChannelT.codecId */
-    stream_write_uint8(s, 0); /* CodecChannelT.channelId */
+    stream_write_uint8(s, 255); /* CodecChannelT.channelId */
     stream_write_uint8(s, 0); /* ctxId */
     stream_write_uint16(s, CT_TILE_64x64); /* tileSize */
 


### PR DESCRIPTION
As per
https://msdn.microsoft.com/en-us/library/ff635385.aspx

> channelId (1 byte): An 8-bit, unsigned integer. Specifies the channel ID. **If the blockType is set to WBT_CONTEXT (0xCCC3), then channelId MUST be set to 0xFF.** 

FreeRDP checks for this and will not establish the session when violated.

Tested fix with xfreerdp connecting to xrdp/xorgxrdp using rfx
