### PR TITLE
Big autotools clreanup, pkg-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Makefile.in
 missing
 NEWS
 *.o
+*.pc
 README
 stamp-h1
 rfxcodectest

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,3 +4,7 @@ SUBDIRS = \
   src \
   tests
 
+include_HEADERS = \
+  include/rfxcodec_encode.h \
+  include/rfxcodec_decode.h \
+  include/rfxcodec_common.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,6 @@
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = rfxcodec.pc
+
 EXTRA_DIST = bootstrap readme.txt
 
 SUBDIRS = \

--- a/bootstrap
+++ b/bootstrap
@@ -29,8 +29,4 @@ then
 fi
 
 touch configure.ac
-touch NEWS
-touch AUTHORS
-touch README
-touch ChangeLog
 autoreconf -fvi

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ AM_CONDITIONAL(WITH_SIMD_X86, [test x$simd_arch = xi386])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  tests/Makefile
+                 rfxcodec.pc
+                 rfxcodec-uninstalled.pc
 ])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -9,12 +9,6 @@ AC_PROG_CC
 AC_C_CONST
 AC_PROG_LIBTOOL
 
-AM_CONDITIONAL(GOT_PREFIX, test "x${prefix}" != "xNONE"])
-
-if test "x${prefix}" = "xNONE" ; then
-sysconfdir="/etc";
-fi
-
 # SIMD is optional
 AC_ARG_WITH([simd],
     AC_HELP_STRING([--without-simd],[Omit SIMD extensions.]))

--- a/rfxcodec-uninstalled.pc.in
+++ b/rfxcodec-uninstalled.pc.in
@@ -1,0 +1,5 @@
+Name: rfxcodec
+Description: Fast jpeg2000 codec compatible with MS RDP servers and xrdp
+Version: @PACKAGE_VERSION@
+Cflags: -I${pc_top_builddir}/${pcfiledir}/include
+Libs: ${pc_top_builddir}/${pcfiledir}/src/librfxencode.la

--- a/rfxcodec.pc.in
+++ b/rfxcodec.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: rfxcodec
+Description: Fast jpeg2000 codec compatible with MS RDP servers and xrdp
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lrfxencode

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,11 +31,6 @@ EXTRA_ENCODE_SRC += $(X86_ASM)
 EXTRA_DEFINES += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_X86=1
 endif
 
-if GOT_PREFIX
-EXTRA_INCLUDES += -I$(prefix)/include
-EXTRA_FLAGS += -L$(prefix)/lib -Wl,-rpath -Wl,$(prefix)/lib
-endif
-
 AM_CFLAGS = \
   -I$(top_srcdir)/include \
   -I../include \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,12 +1,5 @@
 EXTRA_DIST = $(AMD64_ASM) $(X86_ASM) nasm_lt.sh
 
-EXTRA_DEFINES =
-EXTRA_INCLUDES =
-EXTRA_LIBS =
-EXTRA_FLAGS =
-EXTRA_SRC =
-EXTRA_ENCODE_SRC =
-
 AMD64_ASM = \
   amd64/cpuid_amd64.asm \
   amd64/rfxcodec_encode_diff_rlgr1_amd64_sse2.asm \
@@ -21,22 +14,21 @@ X86_ASM = \
   x86/rfxcodec_encode_dwt_shift_x86_sse2.asm \
   x86/rfxcodec_encode_dwt_shift_x86_sse41.asm
 
+ASM_SOURCES =
+
+AM_CPPFLAGS = \
+  -I$(top_srcdir)/include \
+  -I../include
+
 if WITH_SIMD_AMD64
-EXTRA_ENCODE_SRC += $(AMD64_ASM)
-EXTRA_DEFINES += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_AMD64=1
+ASM_SOURCES += $(AMD64_ASM)
+AM_CPPFLAGS += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_AMD64=1
 endif
 
 if WITH_SIMD_X86
-EXTRA_ENCODE_SRC += $(X86_ASM)
-EXTRA_DEFINES += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_X86=1
+ASM_SOURCES += $(X86_ASM)
+AM_CPPFLAGS += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_X86=1
 endif
-
-AM_CFLAGS = \
-  -I$(top_srcdir)/include \
-  -I../include \
-  $(EXTRA_DEFINES)
-
-INCLUDES = $(EXTRA_INCLUDES)
 
 noinst_HEADERS = \
   rfx_bitstream.h \
@@ -56,17 +48,10 @@ noinst_HEADERS = \
 
 lib_LTLIBRARIES = librfxencode.la
 
-librfxencode_la_LDFLAGS = $(EXTRA_FLAGS)
-
-
-librfxencode_ladir = $(moduledir)
-
 librfxencode_la_SOURCES = $(noinst_HEADERS) rfxencode.c \
   rfxcompose.c rfxencode_tile.c rfxencode_dwt.c \
   rfxencode_quantization.c rfxencode_differential.c \
-  rfxencode_rlgr1.c rfxencode_rlgr3.c rfxencode_alpha.c $(EXTRA_ENCODE_SRC)
+  rfxencode_rlgr1.c rfxencode_rlgr3.c rfxencode_alpha.c $(ASM_SOURCES)
 
 .asm.lo:
 	$(LIBTOOL) --mode=compile --tag NASM $(srcdir)/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@
-
-librfxencode_la_LIBADD =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST =
+EXTRA_DIST = $(AMD64_ASM) $(X86_ASM) nasm_lt.sh
 
 EXTRA_DEFINES =
 EXTRA_INCLUDES =
@@ -7,21 +7,27 @@ EXTRA_FLAGS =
 EXTRA_SRC =
 EXTRA_ENCODE_SRC =
 
-if WITH_SIMD_AMD64
-EXTRA_ENCODE_SRC += amd64/cpuid_amd64.asm \
+AMD64_ASM = \
+  amd64/cpuid_amd64.asm \
   amd64/rfxcodec_encode_diff_rlgr1_amd64_sse2.asm \
   amd64/rfxcodec_encode_diff_rlgr3_amd64_sse2.asm \
   amd64/rfxcodec_encode_dwt_shift_amd64_sse2.asm \
   amd64/rfxcodec_encode_dwt_shift_amd64_sse41.asm
-EXTRA_DEFINES += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_AMD64=1
-endif
 
-if WITH_SIMD_X86
-EXTRA_ENCODE_SRC += x86/cpuid_x86.asm \
+X86_ASM = \
+  x86/cpuid_x86.asm \
   x86/rfxcodec_encode_diff_rlgr1_x86_sse2.asm \
   x86/rfxcodec_encode_diff_rlgr3_x86_sse2.asm \
   x86/rfxcodec_encode_dwt_shift_x86_sse2.asm \
   x86/rfxcodec_encode_dwt_shift_x86_sse41.asm
+
+if WITH_SIMD_AMD64
+EXTRA_ENCODE_SRC += $(AMD64_ASM)
+EXTRA_DEFINES += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_AMD64=1
+endif
+
+if WITH_SIMD_X86
+EXTRA_ENCODE_SRC += $(X86_ASM)
 EXTRA_DEFINES += -DSIMD_USE_ACCEL=1 -DRFX_USE_ACCEL_X86=1
 endif
 
@@ -30,9 +36,28 @@ EXTRA_INCLUDES += -I$(prefix)/include
 EXTRA_FLAGS += -L$(prefix)/lib -Wl,-rpath -Wl,$(prefix)/lib
 endif
 
-AM_CFLAGS = -I../include $(EXTRA_DEFINES)
+AM_CFLAGS = \
+  -I$(top_srcdir)/include \
+  -I../include \
+  $(EXTRA_DEFINES)
 
 INCLUDES = $(EXTRA_INCLUDES)
+
+noinst_HEADERS = \
+  rfx_bitstream.h \
+  rfxcommon.h \
+  rfxcompose.h \
+  rfxconstants.h \
+  rfxencode_alpha.h \
+  rfxencode_differential.h \
+  rfxencode_dwt.h \
+  rfxencode.h \
+  rfxencode_quantization.h \
+  rfxencode_rlgr1.h \
+  rfxencode_rlgr3.h \
+  rfxencode_tile.h \
+  amd64/funcs_amd64.h \
+  x86/funcs_x86.h
 
 lib_LTLIBRARIES = librfxencode.la
 
@@ -41,7 +66,7 @@ librfxencode_la_LDFLAGS = $(EXTRA_FLAGS)
 
 librfxencode_ladir = $(moduledir)
 
-librfxencode_la_SOURCES = rfxencode.c \
+librfxencode_la_SOURCES = $(noinst_HEADERS) rfxencode.c \
   rfxcompose.c rfxencode_tile.c rfxencode_dwt.c \
   rfxencode_quantization.c rfxencode_differential.c \
   rfxencode_rlgr1.c rfxencode_rlgr3.c rfxencode_alpha.c $(EXTRA_ENCODE_SRC)
@@ -50,6 +75,3 @@ librfxencode_la_SOURCES = rfxencode.c \
 	$(LIBTOOL) --mode=compile --tag NASM $(srcdir)/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@
 
 librfxencode_la_LIBADD =
-
-include_HEADERS = ../include/rfxcodec_encode.h
-

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,11 +5,6 @@ EXTRA_INCLUDES =
 EXTRA_LIBS =
 EXTRA_FLAGS =
 
-if GOT_PREFIX
-EXTRA_INCLUDES += -I$(prefix)/include
-EXTRA_FLAGS += -L$(prefix)/lib -Wl,-rpath -Wl,$(prefix)/lib
-endif
-
 INCLUDES = \
   -I$(top_srcdir)/include \
   $(EXTRA_INCLUDES)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,20 +1,11 @@
-
 EXTRA_DIST = readme.txt
 
-EXTRA_INCLUDES =
-EXTRA_LIBS =
-EXTRA_FLAGS =
-
-INCLUDES = \
-  -I$(top_srcdir)/include \
-  $(EXTRA_INCLUDES)
+AM_CPPFLAGS = \
+  -I$(top_srcdir)/include
 
 bin_PROGRAMS = rfxcodectest
 
 rfxcodectest_SOURCES = rfxcodectest.c
 
 rfxcodectest_LDADD = \
-  $(top_builddir)/src/librfxencode.la $(EXTRA_LIBS)
-
-rfxcodectest_LDFLAGS = $(EXTRA_FLAGS)
-
+  $(top_builddir)/src/librfxencode.la


### PR DESCRIPTION
pkg-config is a great tool that would enable xrdp to detect rfxcodec easily and even compile against compiled, but not installed sources.

But first of all, let's use autotools properly.
