### PR TITLE
Mark stack non-executable in asm sources

### DIFF
--- a/src/amd64/cpuid_amd64.asm
+++ b/src/amd64/cpuid_amd64.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf64
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 SECTION .text
 

--- a/src/amd64/rfxcodec_encode_diff_rlgr1_amd64_sse2.asm
+++ b/src/amd64/rfxcodec_encode_diff_rlgr1_amd64_sse2.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 section .data
     const1 times 8 dw 1

--- a/src/amd64/rfxcodec_encode_diff_rlgr3_amd64_sse2.asm
+++ b/src/amd64/rfxcodec_encode_diff_rlgr3_amd64_sse2.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 section .data
     const1 times 8 dw 1

--- a/src/amd64/rfxcodec_encode_dwt_shift_amd64_sse2.asm
+++ b/src/amd64/rfxcodec_encode_dwt_shift_amd64_sse2.asm
@@ -19,6 +19,10 @@
 ;
 ;amd64 asm dwt
 
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 section .data
     align 16
     cw128    times 8 dw 128

--- a/src/amd64/rfxcodec_encode_dwt_shift_amd64_sse41.asm
+++ b/src/amd64/rfxcodec_encode_dwt_shift_amd64_sse41.asm
@@ -19,6 +19,10 @@
 ;
 ;amd64 asm dwt
 
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 section .data
     align 16
     cw128    times 8 dw 128

--- a/src/x86/cpuid_x86.asm
+++ b/src/x86/cpuid_x86.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf
+SECTION .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 SECTION .text
 

--- a/src/x86/rfxcodec_encode_diff_rlgr1_x86_sse2.asm
+++ b/src/x86/rfxcodec_encode_diff_rlgr1_x86_sse2.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 section .data
     const1 times 8 dw 1

--- a/src/x86/rfxcodec_encode_diff_rlgr3_x86_sse2.asm
+++ b/src/x86/rfxcodec_encode_diff_rlgr3_x86_sse2.asm
@@ -1,3 +1,6 @@
+%ifidn __OUTPUT_FORMAT__,elf
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
 
 section .data
     const1 times 8 dw 1

--- a/src/x86/rfxcodec_encode_dwt_shift_x86_sse2.asm
+++ b/src/x86/rfxcodec_encode_dwt_shift_x86_sse2.asm
@@ -19,6 +19,10 @@
 ;
 ;x86 asm dwt
 
+%ifidn __OUTPUT_FORMAT__,elf
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 section .data
     align 16
     cw128    times 8 dw 128

--- a/src/x86/rfxcodec_encode_dwt_shift_x86_sse41.asm
+++ b/src/x86/rfxcodec_encode_dwt_shift_x86_sse41.asm
@@ -19,6 +19,10 @@
 ;
 ;x86 asm dwt
 
+%ifidn __OUTPUT_FORMAT__,elf
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+
 section .data
     align 16
     cw128    times 8 dw 128


### PR DESCRIPTION
It is the responsibility of the source files to list the constraints on the code. If the constraints for the stack section are not specified, the linker assumes that some code needs executable stack. Executable stack is considered a threat to security and should be avoided.
