### PR TITLE
Fixes for assembly code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,4 +54,4 @@ librfxencode_la_SOURCES = $(noinst_HEADERS) rfxencode.c \
   rfxencode_rlgr1.c rfxencode_rlgr3.c rfxencode_alpha.c $(ASM_SOURCES)
 
 .asm.lo:
-	$(LIBTOOL) --mode=compile --tag NASM $(srcdir)/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@
+	$(LIBTOOL) --mode=compile $(srcdir)/nasm_lt.sh $(NASM) $(NAFLAGS) -I$(srcdir) -I. $< -o $@

--- a/src/amd64/funcs_amd64.h
+++ b/src/amd64/funcs_amd64.h
@@ -24,6 +24,10 @@ amd64 asm files
 #ifndef __FUNCS_AMD64_H
 #define __FUNCS_AMD64_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int
 cpuid_amd64(int eax_in, int ecx_in, int *eax, int *ebx, int *ecx, int *edx);
 
@@ -60,5 +64,8 @@ rfxcodec_decode_yuva2argb_amd64_sse2(short *ydata, short *udata,
                                      short *vdata, char *adata,
                                      unsigned int *rgbdata, int stride);
 
+#ifdef __cplusplus
+}
 #endif
 
+#endif

--- a/src/amd64/rfxcodec_encode_diff_rlgr3_amd64_sse2.asm
+++ b/src/amd64/rfxcodec_encode_diff_rlgr3_amd64_sse2.asm
@@ -5,6 +5,8 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 section .data
     const1 times 8 dw 1
 
+section .text
+
 %macro PROC 1
     align 16
     global %1

--- a/src/x86/funcs_x86.h
+++ b/src/x86/funcs_x86.h
@@ -33,6 +33,12 @@ rfxcodec_encode_dwt_shift_x86_sse2(const char *qtable,
                                    short *dwt_buffer1,
                                    short *dwt_buffer);
 int
+rfxcodec_encode_dwt_shift_x86_sse41(const char *qtable,
+                                    unsigned char *data,
+                                    short *dwt_buffer1,
+                                    short *dwt_buffer);
+
+int
 rfxcodec_encode_diff_rlgr1_x86_sse2(short *co,
                                     void *dst, int dst_bytes);
 int

--- a/src/x86/funcs_x86.h
+++ b/src/x86/funcs_x86.h
@@ -24,6 +24,10 @@ x86 asm files
 #ifndef __FUNCS_X86_H
 #define __FUNCS_X86_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int
 cpuid_x86(int eax_in, int ecx_in, int *eax, int *ebx, int *ecx, int *edx);
 
@@ -61,5 +65,8 @@ rfxcodec_decode_yuva2argb_x86_sse2(short *ydata, short *udata,
                                    short *vdata, char *adata,
                                    unsigned int *rgbdata, int stride);
 
+#ifdef __cplusplus
+}
 #endif
 
+#endif

--- a/src/x86/rfxcodec_encode_diff_rlgr1_x86_sse2.asm
+++ b/src/x86/rfxcodec_encode_diff_rlgr1_x86_sse2.asm
@@ -5,6 +5,8 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 section .data
     const1 times 8 dw 1
 
+section .text
+
 %macro PROC 1
     align 16
     global %1

--- a/src/x86/rfxcodec_encode_diff_rlgr3_x86_sse2.asm
+++ b/src/x86/rfxcodec_encode_diff_rlgr3_x86_sse2.asm
@@ -5,6 +5,8 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 section .data
     const1 times 8 dw 1
 
+section .text
+
 %macro PROC 1
     align 16
     global %1


### PR DESCRIPTION
The declaration for rfxcodec_encode_dwt_shift_x86_sse41() was missing. It caused a warning on x86. If compiled with a C++ compiler, it's an error.

Use extern "C" wrapper in the headers to allow access to the assemble functions from C++ code.

Some of the assembly files lacked `section .text` which lead to the functions appearing as data (`D`) in nm listings.