### PR TITLE
Add include/Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,10 +5,6 @@ pkgconfig_DATA = rfxcodec.pc
 EXTRA_DIST = bootstrap readme.txt
 
 SUBDIRS = \
+  include \
   src \
   tests
-
-include_HEADERS = \
-  include/rfxcodec_encode.h \
-  include/rfxcodec_decode.h \
-  include/rfxcodec_common.h

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,7 @@ AM_CONDITIONAL(WITH_SIMD_AMD64, [test x$simd_arch = xx86_64])
 AM_CONDITIONAL(WITH_SIMD_X86, [test x$simd_arch = xi386])
 
 AC_CONFIG_FILES([Makefile
+                 include/Makefile
                  src/Makefile
                  tests/Makefile
                  rfxcodec.pc

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,0 +1,4 @@
+include_HEADERS = \
+  rfxcodec_encode.h \
+  rfxcodec_decode.h \
+  rfxcodec_common.h


### PR DESCRIPTION
It's generally better to have Makefile.am in every directory rather than
manage files in one directory from Makefile.am in another directory.