### PR TITLE
Use AC_LINK_IFELSE to test compiler and nasm compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 env:
   - CONF_FLAGS=""
   - CONF_FLAGS="--without-simd"
-  - CONG_FLAGS="--host=i686-linux CFLAGS=-m32 LDFLAGS=-m32"
+  - CONG_FLAGS="--host=i686-linux CFLAGS=-m32"
 
 script:
   - ./bootstrap


### PR DESCRIPTION
Use AC_LINK_IFELSE to test compiler and nasm compatibility

AC_LINK_IFELSE is guaranteed to use the same compiler executable and
flags as other compiler tests. Specifically, it uses CFLAGS when linking.

Change conftest.asm to provide a function other than main(), so that
main() comes from the C file. That actually checks calling nasm compiled
functions from C sources.