### PR TITLE
clear trailing bits in rlgr1/3 old and new

### DIFF
--- a/src/rfx_bitstream.h
+++ b/src/rfx_bitstream.h
@@ -68,7 +68,7 @@ typedef struct _RFX_BITSTREAM RFX_BITSTREAM;
         b = nbits; \
         if (b > bs.bits_left) \
             b = bs.bits_left; \
-        bs.buffer[bs.byte_pos] &= ~(((1 << b) - 1) << (bs.bits_left - b)); \
+        bs.buffer[bs.byte_pos] &= ~((1 << bs.bits_left) - 1); \
         bs.buffer[bs.byte_pos] |= ((bits >> (nbits - b)) & ((1 << b) - 1)) << (bs.bits_left - b); \
         bs.bits_left -= b; \
         nbits -= b; \

--- a/src/rfxencode_diff_rlgr1.c
+++ b/src/rfxencode_diff_rlgr1.c
@@ -240,7 +240,6 @@ rfx_encode_diff_rlgr1(sint16 *coef, uint8 *cdata, int cdata_size)
     if (bit_count > 0)
     {
         bits <<= 8 - bit_count;
-        bits |= ((1 << (8 - bit_count)) - 1) & *cdata;
         *cdata = bits;
         cdata++;
         bit_count = 0;

--- a/src/rfxencode_diff_rlgr3.c
+++ b/src/rfxencode_diff_rlgr3.c
@@ -277,7 +277,6 @@ rfx_encode_diff_rlgr3(sint16 *coef, uint8 *cdata, int cdata_size)
     if (bit_count > 0)
     {
         bits <<= 8 - bit_count;
-        bits |= ((1 << (8 - bit_count)) - 1) & *cdata;
         *cdata = bits;
         cdata++;
         bit_count = 0;


### PR DESCRIPTION
In order to automate testing, we need to clear the trailing bits in last byte.
The garbage can cause false fails.