### PR TITLE
Check for space in buffer before writing tiles

### DIFF
--- a/src/rfxencode.c
+++ b/src/rfxencode.c
@@ -314,6 +314,7 @@ rfxcodec_encode_ex(void *handle, char *cdata, int *cdata_bytes,
                    const char *quants, int num_quants, int flags)
 {
     struct rfxencode *enc;
+    int tiles_written;
     STREAM s;
 
     enc = (struct rfxencode *) handle;
@@ -327,18 +328,15 @@ rfxcodec_encode_ex(void *handle, char *cdata, int *cdata_bytes,
     {
         if (rfx_compose_message_header(enc, &s) != 0)
         {
-            return 1;
+            return -1;
         }
     }
-    if (rfx_compose_message_data(enc, &s, regions, num_regions,
-                                 buf, width, height, stride_bytes,
-                                 tiles, num_tiles, quants, num_quants,
-                                 flags) != 0)
-    {
-        return 1;
-    }
+    tiles_written = rfx_compose_message_data(enc, &s, regions, num_regions,
+                                            buf, width, height, stride_bytes,
+                                            tiles, num_tiles,
+                                            quants, num_quants, flags);
     *cdata_bytes = (int) (s.p - s.data);
-    return 0;
+    return tiles_written;
 }
 
 /******************************************************************************/

--- a/src/rfxencode_compose.c
+++ b/src/rfxencode_compose.c
@@ -452,6 +452,8 @@ rfx_compose_message_tileset(struct rfxencode *enc, STREAM *s,
     s->p += numQuants * 5;
     end_pos = stream_get_pos(s);
     tiles_written = 0;
+    tiles_end_checkpoint = stream_get_pos(s);
+
     if (enc->format == RFX_FORMAT_YUV)
     {
         if (flags & RFX_FLAGS_ALPHAV1)

--- a/src/rfxencode_tile.c
+++ b/src/rfxencode_tile.c
@@ -51,6 +51,23 @@
 #define LLOGLN(_level, _args) \
     do { if (_level < LLOG_LEVEL) { printf _args ; printf("\n"); } } while (0)
 
+/**
+ * In order not to overflow the output buffer, we need to have an
+ * upper limit on the size of a tile which could possibly be written to
+ * the buffer.
+ *
+ * The tile data structure (TS_RFX_TILE) is defined in [MS-RDPRFX]
+ * 2.2.2.3.4.1
+ *
+ * We make the conservative assumption that the RLGR1/RLGL3 algorithm
+ * worst case results in a doubling of the YCbCr data for each pixel.
+ * This is likely to be far higher than necessary.
+ */
+#define RLGR_WORST_CASE_SIZE_FACTOR 2
+#define TILE_SIZE_UPPER_LIMIT (6 + 1 + 1 + 1 + 2 + 2 + 2 + 2 + 2 + \
+                                (64 * 64) * 3 * RLGR_WORST_CASE_SIZE_FACTOR)
+
+
 /******************************************************************************/
 int
 rfx_encode_component_rlgr1(struct rfxencode *enc, const char *qtable,
@@ -103,7 +120,7 @@ check_and_rfx_encode(struct rfxencode *enc, const char *qtable,
                      const uint8 *data,
                      uint8 *buffer, int buffer_size, int *size)
 {
-    if (buffer_size < 4096 * 2)
+    if (buffer_size < TILE_SIZE_UPPER_LIMIT)
     {
         return 1;
     }

--- a/src/rfxencode_tile.c
+++ b/src/rfxencode_tile.c
@@ -98,6 +98,19 @@ rfx_encode_component_rlgr3(struct rfxencode *enc, const char *qtable,
 }
 
 /******************************************************************************/
+static int
+check_and_rfx_encode(struct rfxencode *enc, const char *qtable,
+                     const uint8 *data,
+                     uint8 *buffer, int buffer_size, int *size)
+{
+    if (buffer_size < 4096 * 2)
+    {
+        return 1;
+    }
+    return enc->rfx_encode(enc, qtable, data, buffer, buffer_size, size);
+}
+
+/******************************************************************************/
 int
 rfx_encode_rgb(struct rfxencode *enc, const char *rgb_data,
                int width, int height, int stride_bytes,
@@ -118,28 +131,28 @@ rfx_encode_rgb(struct rfxencode *enc, const char *rgb_data,
     y_r_buffer = enc->y_r_buffer;
     u_g_buffer = enc->u_g_buffer;
     v_b_buffer = enc->v_b_buffer;
-    if (enc->rfx_encode(enc, y_quants, y_r_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        y_size) != 0)
+    if (check_and_rfx_encode(enc, y_quants, y_r_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             y_size) != 0)
     {
         return 1;
     }
     LLOGLN(10, ("rfx_encode_rgb: y_size %d", *y_size));
     stream_seek(data_out, *y_size);
-    if (enc->rfx_encode(enc, u_quants, u_g_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        u_size) != 0)
+    if (check_and_rfx_encode(enc, u_quants, u_g_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             u_size) != 0)
     {
         return 1;
     }
     LLOGLN(10, ("rfx_encode_rgb: u_size %d", *u_size));
     stream_seek(data_out, *u_size);
-    if (enc->rfx_encode(enc, v_quants, v_b_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        v_size) != 0)
+    if (check_and_rfx_encode(enc, v_quants, v_b_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             v_size) != 0)
     {
         return 1;
     }
@@ -172,28 +185,28 @@ rfx_encode_argb(struct rfxencode *enc, const char *argb_data,
     y_r_buffer = enc->y_r_buffer;
     u_g_buffer = enc->u_g_buffer;
     v_b_buffer = enc->v_b_buffer;
-    if (enc->rfx_encode(enc, y_quants, y_r_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        y_size) != 0)
+    if (check_and_rfx_encode(enc, y_quants, y_r_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             y_size) != 0)
     {
         return 1;
     }
     LLOGLN(10, ("rfx_encode_rgb: y_size %d", *y_size));
     stream_seek(data_out, *y_size);
-    if (enc->rfx_encode(enc, u_quants, u_g_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        u_size) != 0)
+    if (check_and_rfx_encode(enc, u_quants, u_g_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             u_size) != 0)
     {
         return 1;
     }
     LLOGLN(10, ("rfx_encode_rgb: u_size %d", *u_size));
     stream_seek(data_out, *u_size);
-    if (enc->rfx_encode(enc, v_quants, v_b_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        v_size) != 0)
+    if (check_and_rfx_encode(enc, v_quants, v_b_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             v_size) != 0)
     {
         return 1;
     }
@@ -218,26 +231,26 @@ rfx_encode_yuv(struct rfxencode *enc, const char *yuv_data,
     y_buffer = (const uint8 *) yuv_data;
     u_buffer = (const uint8 *) (yuv_data + RFX_YUV_BTES);
     v_buffer = (const uint8 *) (yuv_data + RFX_YUV_BTES * 2);
-    if (enc->rfx_encode(enc, y_quants, y_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        y_size) != 0)
+    if (check_and_rfx_encode(enc, y_quants, y_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             y_size) != 0)
     {
         return 1;
     }
     stream_seek(data_out, *y_size);
-    if (enc->rfx_encode(enc, u_quants, u_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        u_size) != 0)
+    if (check_and_rfx_encode(enc, u_quants, u_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             u_size) != 0)
     {
         return 1;
     }
     stream_seek(data_out, *u_size);
-    if (enc->rfx_encode(enc, v_quants, v_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        v_size) != 0)
+    if (check_and_rfx_encode(enc, v_quants, v_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             v_size) != 0)
     {
         return 1;
     }
@@ -263,26 +276,26 @@ rfx_encode_yuva(struct rfxencode *enc, const char *yuva_data,
     u_buffer = (const uint8 *) (yuva_data + RFX_YUV_BTES);
     v_buffer = (const uint8 *) (yuva_data + RFX_YUV_BTES * 2);
     a_buffer = (const uint8 *) (yuva_data + RFX_YUV_BTES * 3);
-    if (enc->rfx_encode(enc, y_quants, y_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        y_size) != 0)
+    if (check_and_rfx_encode(enc, y_quants, y_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             y_size) != 0)
     {
         return 1;
     }
     stream_seek(data_out, *y_size);
-    if (enc->rfx_encode(enc, u_quants, u_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        u_size) != 0)
+    if (check_and_rfx_encode(enc, u_quants, u_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             u_size) != 0)
     {
         return 1;
     }
     stream_seek(data_out, *u_size);
-    if (enc->rfx_encode(enc, v_quants, v_buffer,
-                        stream_get_tail(data_out),
-                        stream_get_left(data_out),
-                        v_size) != 0)
+    if (check_and_rfx_encode(enc, v_quants, v_buffer,
+                             stream_get_tail(data_out),
+                             stream_get_left(data_out),
+                             v_size) != 0)
     {
         return 1;
     }

--- a/tests/rfxcodectest.c
+++ b/tests/rfxcodectest.c
@@ -125,7 +125,7 @@ speed_random(int count, const char *quants)
         error = rfxcodec_encode_ex(han, cdata, &cdata_bytes, buf, 64, 64, 64 * 4,
                                    regions, num_regions, tiles, num_tiles,
                                    quants, num_quants, flags);
-        if (error != 0)
+        if (error < num_tiles)
         {
             break;
         }
@@ -295,7 +295,7 @@ encode_file(char *data, int width, int height, char *cdata, int *cdata_bytes,
     error = rfxcodec_encode_ex(han, cdata, cdata_bytes, data, width, height, width * 4,
                                regions, num_regions, tiles, num_tiles,
                                quants, num_quants, 0);
-    if (error != 0)
+    if (error < num_tiles)
     {
         printf("encode_file: rfxcodec_encode failed error %d\n", error);
         return 1;

--- a/tests/rfxencode.c
+++ b/tests/rfxencode.c
@@ -248,7 +248,7 @@ int process(void)
             error = rfxcodec_encode(han, out_data, &out_bytes, bmp_data,
                                     width, height, width * 4,
                                     &region, 1, tiles, num_tiles, NULL, 0);
-            if (error != 0)
+            if (error < num_tiles)
             {
                 break;
             }


### PR DESCRIPTION
This is a required part of the fix for neutrinolabs/xrdp#2068

Thanks to @trishume for supplying this patch.