### PR TITLE
Force static library only

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,6 +38,8 @@ noinst_HEADERS = \
 
 lib_LTLIBRARIES = librfxencode.la
 
+librfxencode_la_LDFLAGS = -all-static
+
 librfxencode_la_SOURCES = $(noinst_HEADERS) rfxencode.c \
   rfxencode_compose.c rfxencode_tile.c rfxencode_dwt.c \
   rfxencode_quantization.c rfxencode_differential.c \


### PR DESCRIPTION
See neutrinolabs/xrdp#1467

This library is only statically linked, so there's not need to build the dynamic one. If `--disable-static` is specified for the xrdp configure, this library still needs to be statically linked.