### PR TITLE
Bump autoconf ver

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script
 
-AC_PREREQ(2.59)
+AC_PREREQ(2.69)
 AC_INIT([rfxcodec], [0.1.6], [xrdp-devel@googlegroups.com])
 AC_CONFIG_HEADERS(config_ac.h:config_ac-h.in)
 AM_INIT_AUTOMAKE([1.6 foreign])
@@ -8,7 +8,7 @@ AC_CONFIG_MACRO_DIR([m4])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_PROG_CC
 AC_C_CONST
-AC_PROG_LIBTOOL
+LT_INIT
 PKG_INSTALLDIR
 
 AX_CFLAGS_WARN_ALL
@@ -16,7 +16,7 @@ AX_APPEND_COMPILE_FLAGS([-Wwrite-strings])
 
 # SIMD is optional
 AC_ARG_WITH([simd],
-    AC_HELP_STRING([--without-simd],[Omit SIMD extensions.]))
+    AS_HELP_STRING([--without-simd],[Omit SIMD extensions.]))
 if test "x${with_simd}" != "xno"; then
   # Check if we're on a supported CPU
   AC_MSG_CHECKING([if we have SIMD optimisations for cpu type])

--- a/m4/nasm.m4
+++ b/m4/nasm.m4
@@ -116,8 +116,8 @@ try_nasm='$NASM $NAFLAGS -o conftest-nasm.o conftest.asm'
 if AC_TRY_EVAL(try_nasm) && test -s conftest-nasm.o; then
   AC_MSG_RESULT(yes)
 else
-  echo "configure: failed program was:" >&AC_FD_CC
-  cat conftest.asm >&AC_FD_CC
+  echo "configure: failed program was:" >&AS_MESSAGE_LOG_FD
+  cat conftest.asm >&AS_MESSAGE_LOG_FD
   rm -rf conftest*
   AC_MSG_RESULT(no)
   AC_MSG_ERROR([installation or configuration problem: assembler cannot create object files.])


### PR DESCRIPTION
The version of autoconf on Ubuntu 22.04 (2.71) produces warnings regarding obsolete macros AC_PROG_LIBTOOL and AC_FD_CC.

This PR bumps the autoconf version to 2.69 (used by CentOS 7 and Ubuntu 16.04) and replaces the obsolete macros with supported ones.