### PR TITLE
Fix warning with cppcheck 2.11

### DIFF
--- a/tests/rfxencode.c
+++ b/tests/rfxencode.c
@@ -170,7 +170,7 @@ int process(void)
     char *out_data;
     char *bmp_data;
     int out_fd;
-    int out_bytes;
+    int out_bytes = 0;
     int error;
     int index;
     int index_x;


### PR DESCRIPTION
This is needed to move xrdp to the latest cppcheck

cppcheck 2.11 generates a warning for an uninitialised variable as follows:-

librfxcodec/tests/rfxencode.c:245:31: note: Assuming condition is false
        for (index = 0; index < g_count; index++)
                              ^
librfxcodec/tests/rfxencode.c:257:16: note: Uninitialized variable: out_bytes
               out_bytes, num_tiles);
               ^