### PR TITLE
Fix compile warnings in tests/test_dwt_rem.c

### DIFF
--- a/tests/test_dwt_rem.c
+++ b/tests/test_dwt_rem.c
@@ -17,6 +17,13 @@ main(int argc, char **argv)
     struct rfxcodec_encode_internals internals;
     int error;
     int index;
+
+    unsigned char in_buffer[4096];
+    short out_buffer1[4096];
+    short tmp_buffer1[4096];
+    //char quans[5] = { 0x66, 0x66, 0x66, 0x66, 0x66 };
+    char quans[5] = { 0x99, 0x99, 0x99, 0x99, 0x99 };
+#if 0
     short diff_buffer1[4096];
     short diff_buffer2[4096];
     short dwt_buffer[4096];
@@ -25,18 +32,12 @@ main(int argc, char **argv)
     int dwt_zeros1;
     int diff_zeros2;
     int dwt_zeros2;
-
-    unsigned char in_buffer[4096];
-    short out_buffer1[4096];
     short out_buffer2[4096];
-    short tmp_buffer1[4096];
     short tmp_buffer2[4096];
-    //char quans[5] = { 0x66, 0x66, 0x66, 0x66, 0x66 };
-    char quans[5] = { 0x99, 0x99, 0x99, 0x99, 0x99 };
     int fd;
 
     fd = open("/dev/urandom", O_RDONLY);
-
+#endif
     error = rfxcodec_encode_get_internals(&internals);
     if (error == 0)
     {


### PR DESCRIPTION
Fixes these warnings with "-Wall -Werror" :-

```
test_dwt_rem.c: In function ‘main’:
test_dwt_rem.c:36:9: error: variable ‘fd’ set but not used [-Werror=unused-but-set-variable]
   36 |     int fd;
      |         ^~
test_dwt_rem.c:33:11: error: unused variable ‘tmp_buffer2’ [-Werror=unused-variable]
   33 |     short tmp_buffer2[4096];
      |           ^~~~~~~~~~~
test_dwt_rem.c:31:11: error: unused variable ‘out_buffer2’ [-Werror=unused-variable]
   31 |     short out_buffer2[4096];
      |           ^~~~~~~~~~~
test_dwt_rem.c:27:9: error: unused variable ‘dwt_zeros2’ [-Werror=unused-variable]
   27 |     int dwt_zeros2;
      |         ^~~~~~~~~~
test_dwt_rem.c:26:9: error: unused variable ‘diff_zeros2’ [-Werror=unused-variable]
   26 |     int diff_zeros2;
      |         ^~~~~~~~~~~
test_dwt_rem.c:25:9: error: unused variable ‘dwt_zeros1’ [-Werror=unused-variable]
   25 |     int dwt_zeros1;
      |         ^~~~~~~~~~
test_dwt_rem.c:24:9: error: unused variable ‘diff_zeros1’ [-Werror=unused-variable]
   24 |     int diff_zeros1;
      |         ^~~~~~~~~~~
test_dwt_rem.c:23:11: error: unused variable ‘hist_buffer’ [-Werror=unused-variable]
   23 |     short hist_buffer[4096];
      |           ^~~~~~~~~~~
test_dwt_rem.c:22:11: error: unused variable ‘dwt_buffer’ [-Werror=unused-variable]
   22 |     short dwt_buffer[4096];
      |           ^~~~~~~~~~
test_dwt_rem.c:21:11: error: unused variable ‘diff_buffer2’ [-Werror=unused-variable]
   21 |     short diff_buffer2[4096];
      |           ^~~~~~~~~~~~
test_dwt_rem.c:20:11: error: unused variable ‘diff_buffer1’ [-Werror=unused-variable]
   20 |     short diff_buffer1[4096];
      |           ^~~~~~~~~~~~
```