### PR TITLE
Add support for cppcheck 2.17.0

### DIFF
--- a/src/neon/rfxencode_dwt_shift_rem_neon.c
+++ b/src/neon/rfxencode_dwt_shift_rem_neon.c
@@ -212,8 +212,8 @@ rfx_encode_dwt_shift_rem_horz_lv1(const sint16 *in_buffer, sint16 *out_buffer,
     sint16 ic64;
     int n;
     int y;
-    int lo_fact;
-    int hi_fact;
+    int lo_fact = 0;
+    int hi_fact = 0;
     int lo_half;
     int hi_half;
 
@@ -417,8 +417,8 @@ rfx_encode_dwt_shift_rem_horz_lv2(const sint16 *in_buffer, sint16 *out_buffer,
     sint16 hn;          /* H[n]      */
     sint16 ic30;
     int y;
-    int lo_fact;
-    int hi_fact;
+    int lo_fact = 0;
+    int hi_fact = 0;
     int lo_half;
     int hi_half;
 
@@ -614,8 +614,8 @@ rfx_encode_dwt_shift_rem_horz_lv3(const sint16 *in_buffer, sint16 *out_buffer,
     sint16 hn;          /* H[n]      */
     sint16 ic14;
     int y;
-    int lo_fact;
-    int hi_fact;
+    int lo_fact = 0;
+    int hi_fact = 0;
     int lo_half;
     int hi_half;
 

--- a/tests/rfxencode.c
+++ b/tests/rfxencode.c
@@ -191,6 +191,10 @@ process(void)
 
     out_data = (char *) malloc(MAX_OUT_DATA_BYTES);
     bmp_data = (char *) malloc(MAX_BMP_DATA_BYTES);
+    if (out_data == NULL || bmp_data == NULL)
+    {
+        abort();
+    }
     memset(bmp_data, 0xff, MAX_BMP_DATA_BYTES);
 
     if (read_bitmap(g_in_filename, &width, &height, &bpp, bmp_data) != 0)


### PR DESCRIPTION
Part of neutrinolabs/xrdp#3439

Changes:-

1) A few (potentially) uninitialised variables in the NEON code

Errors from cppcheck:-

```
$ scripts/run_cppcheck.sh -v 2.17.0
Cppcheck 2.17.0
Command: /home/mjb/cppcheck.local/2.17.0/bin/cppcheck --quiet --force --std=c11 --std=c++11 --inline-suppr                     --enable=warning --error-exitcode=1 -i third_party                     --suppress=uninitMemberVar:ulalaca/ulalaca.cpp                     --suppress=shiftTooManyBits:libxrdp/xrdp_mppc_enc.c                 --suppress=normalCheckLevelMaxBranches --check-level=normal -I . -I common -D__cppcheck__ -j 8 .
Check level: normal
librfxcodec/src/neon/rfxencode_dwt_shift_rem_neon.c:231:9: error: Uninitialized variable: hi_fact [uninitvar]
        OC_HL1V(0, HIQV(hnv = HI_MATHV(x2nv, x2n1v, x2n2v)));
        ^
librfxcodec/src/neon/rfxencode_dwt_shift_rem_neon.c:273:16: error: Uninitialized variable: lo_fact [uninitvar]
        OC_LH1V(0, LOQV(LO_MATHV(hnv, hn1v, x2nv)));
               ^
librfxcodec/src/neon/rfxencode_dwt_shift_rem_neon.c:436:16: error: Uninitialized variable: hi_fact [uninitvar]
        OC_HL2V(0, HIQV(hnv = HI_MATHV(x2nv, x2n1v, x2n2v)));
               ^
librfxcodec/src/neon/rfxencode_dwt_shift_rem_neon.c:475:16: error: Uninitialized variable: lo_fact [uninitvar]
        OC_LH2V(0, LOQV(LO_MATHV(hnv, hn1v, x2nv)));
               ^
librfxcodec/src/neon/rfxencode_dwt_shift_rem_neon.c:634:16: error: Uninitialized variable: hi_fact [uninitvar]
        OC_HL3V(0, HIQV(hnv = HI_MATHV(x2nv, x2n1v, x2n2v)));
               ^
librfxcodec/src/neon/rfxencode_dwt_shift_rem_neon.c:638:16: error: Uninitialized variable: lo_fact [uninitvar]
        OC_LL3V(0, LOQV(LO_MATHV(hnv, hn1v, x2nv)));
               ^
```
2) Add a very basic check to the tests so that an out-of-memory failure results in defined behaviour. This is needed to stop cppcheck 2.17 complaining about unchecked memory being used.

@jsorg71 - are you happy with the changes to rfxencode_dwt_shift_rem_neon.c?